### PR TITLE
Adds automatic dice selection to bets phase

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -2,14 +2,16 @@ function renderGame(game) {
     fetch('templates/game.mustache')
         .then((response) => response.text())
         .then((template) => {
-            var gameToRender = {
-                "canReroll": game.remainingRerolls > 0,
-                "screen": game.step
+            let gameToRender = {
+                canReroll: game.remainingRerolls > 0 && game.step == Steps.ROLLING,
+                screen: game.step,
+                betsAreSet: game.step == Steps.BETS // TODO: Only when bets are final
             };
             gameToRender.playerDice = game.playerDice.map(function(x, i) {
-                return {"key": i, "value": x};
+                let selected = game.selectedDiceKeys.has(i);
+                return {key: i, value: x, selected: selected};
             });
-            var rendered = Mustache.render(template, gameToRender);
+            let rendered = Mustache.render(template, gameToRender);
             $('#canvas').html(rendered);
         });
 };

--- a/js/script.js
+++ b/js/script.js
@@ -1,23 +1,41 @@
 const MAX_DICE = 5;
 const MAX_REROLLS = 2;
+const SUBGAME_DICE = 3;
 
-var game = {
-    "step": "splash",
-    "playerDice": [],
-    "remainingRerolls": 0,
-    "selectedDiceKeys": new Set()
+let Steps = {
+    SPLASH: "splash",
+    ROLLING: "rolling",
+    BETS: "bets",
+    RESULT: "result"
 };
 
+let Subgames = {
+    BIGGEST: 0,
+    SMALLEST: 1,
+    ONE_AS_TWO: 2,
+    PAIR_PLUS_ACE: 3
+};
+
+var game = {
+    step: Steps.SPLASH,
+    subgame: Subgames.BIGGEST,
+    playerDice: [],
+    remainingRerolls: 0,
+    selectedDiceKeys: new Set()
+};
+
+// Splash step
 function begin() {
     renderGame(game);
-}
+};
 
+// Rolling step
 function rollDie() {
     return Math.floor(Math.random() * 6) + 1;
 };
 
 function rollInitialDice() {
-    game.step = "rolling";
+    game.step = Steps.ROLLING,
     game.selectedDiceKeys.clear();
     game.remainingRerolls = MAX_REROLLS;
     for (const x of Array(MAX_DICE).keys()) {
@@ -45,9 +63,8 @@ function rerollDice() {
 };
 
 function endRollPhase() {
-    console.log("Rematada a fase de tiradas");
-    game.step = "bets";
-    renderGame(game);
+    game.step = Steps.BETS;
+    startSubgame(Subgames.BIGGEST);
 };
 
 function updateSelectedDie(key, checked) {
@@ -56,4 +73,97 @@ function updateSelectedDie(key, checked) {
     } else {
         game.selectedDiceKeys.delete(key);
     }
+};
+
+// Bets step
+function startSubgame(subgame) {
+    game.subgame = subgame;
+    game.selectedDiceKeys.clear();
+    bestDice(subgame, game.playerDice).forEach(x =>
+        game.selectedDiceKeys.add(x)
+    );
+    renderGame(game);
+};
+
+function finishSubgame() {
+    let nextSubgame = game.subgame + 1;
+    if (nextSubgame < Object.keys(Subgames).length) {
+        startSubgame(nextSubgame);
+    } else {
+        // nextPhase
+    }
+};
+
+function bestDice(subgame, dice) {
+    switch(subgame) {
+        case Subgames.BIGGEST:
+            return bestDiceBiggest(dice);
+        case Subgames.SMALLEST:
+            return bestDiceSmallest(dice);
+        case Subgames.ONE_AS_TWO:
+            return bestDiceOneAsTwo(dice);
+        case Subgames.PAIR_PLUS_ACE:
+            return bestDicePairPlusAce(dice);
+    }
+};
+
+function bestDiceBiggest(dice) {
+    let indexedDice = dice.map(function(value, index) {
+        return {value: value, index: index};
+    });
+    indexedDice.sort((a, b) => b.value - a.value);
+    return indexedDice.slice(0, SUBGAME_DICE).map(x => x.index);
+};
+
+function bestDiceSmallest(dice) {
+    let indexedDice = dice.map(function(value, index) {
+        return {value: value, index: index};
+    });
+    indexedDice.sort((a, b) => a.value - b.value);
+    return indexedDice.slice(0, SUBGAME_DICE).map(x => x.index);
+};
+
+function bestDiceOneAsTwo(dice) {
+    for (var i = 0; i < MAX_DICE; i++) {
+        if (dice[i] < 2) {
+            continue;
+        }
+        for (var j = 0; j < MAX_DICE; j++) {
+            if (j == i || dice[j] >= dice[i]) {
+                continue;
+            }
+            for (var k = 0; k < MAX_DICE; k++) {
+                if (k == i || k == j) {
+                    continue;
+                }
+                if (dice[i] == dice[j] + dice[k]) {
+                    return [i, j, k];
+                }
+            }
+        }
+    };
+    return [];
+};
+
+function bestDicePairPlusAce(dice) {
+    var result = [];
+    for (var i = 0; i < MAX_DICE; i++) {
+        if (dice[i] != 1) {
+            continue;
+        }
+        for (var j = 0; j < MAX_DICE; j++) {
+            if (j == i) {
+                continue;
+            }
+            for (var k = 0; k < MAX_DICE; k++) {
+                if (k == i || k == j) {
+                    continue;
+                }
+                if (dice[k] == dice[j] && (result.length == 0 ||  dice[k] > dice[result[1]])) {
+                    result = [i, j, k];
+                }
+            }
+        }
+    };
+    return result;
 };

--- a/styles/style.less
+++ b/styles/style.less
@@ -47,8 +47,8 @@ body {
 		#btnInitialThrow {
 			display: none;
 		}
-		#divDiceButtons {
-			display: none;
+		.checkDie:checked + .labelDie {
+			border: 3px dashed saddlebrown;
 		}
 	}
 }

--- a/templates/game.mustache
+++ b/templates/game.mustache
@@ -5,16 +5,19 @@
             {{#playerDice}}
                 <span>
                     <input id="inputDie{{key}}" type="checkbox" value="die{{key}}" class="checkDie"
-                           onchange="updateSelectedDie({{key}}, this.checked)"/>
+                           onchange="updateSelectedDie({{key}}, this.checked)" {{#selected}}checked{{/selected}}/>
                     <label id="die{{key}}" for="inputDie{{key}}" class="labelDie"><i class="face{{value}}"></i></label>
                 </span>
             {{/playerDice}}
         </div>
-        {{#canReroll}}
-            <div id="divDiceButtons">
+        <div id="divDiceButtons">
+            {{#canReroll}}
                 <button id="btnReroll" onclick="rerollDice()" data-times="0">Rolar de novo</button>
                 <button id="btnEndRolls" onclick="endRollPhase()">Quedar con estes</button>
-            </div>
-        {{/canReroll}}
+            {{/canReroll}}
+            {{#betsAreSet}}
+                <button id="btnFinishSubgame" onClick="finishSubgame()">Continuar</button>
+            {{/betsAreSet}}
+        </div>
     </div>
 </div>


### PR DESCRIPTION
Now, on the bets phase, the best dice are automatically checked to help
the player to identify their combination. This is made via some
functions that we might want to refactor in the future, if only to make
them prettier avoiding the O(n^3) complexity (even though n=5).

I don't know anything about less so the following things remain
pending:
* Ensure that the "Continuar" button appears below the dice.
* Always display the "checked" style for the dice regardless of the
  state, because I think it's useful on all phases.